### PR TITLE
Add capability to query teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ $ go get github.com/jabley/ghcli
 ## Usage
 
 ```shell
-$ GH_OAUTH_TOKEN=a-token-here ghcli members -o alphagov
+$ GH_OAUTH_TOKEN=a-token-here ghcli members alphagov
 ```
 
 This will show all of the members of the organisation alphagov.
+
+```shell
+$ GH_OAUTH_TOKEN=a-token-here ghcli teams alphagov
+```
+
+This will show all of the teams of the organisation alphagov.

--- a/commands/help.go
+++ b/commands/help.go
@@ -45,6 +45,7 @@ var helpText = `
 These commands are provided by ghcli:
 
     members  Work with members
+    teams    Work with teams
 `
 
 func printUsage() {

--- a/commands/teams.go
+++ b/commands/teams.go
@@ -10,50 +10,52 @@ import (
 )
 
 var (
-	cmdMembers = &Command{
-		Run:   listMembers,
-		Usage: "members ORGANISATION",
+	cmdTeams = &Command{
+		Run:   listTeams,
+		Usage: "teams ORGANISATION",
 		Long: `List the members of the organisation
 
 ## Options:
 
 `,
 	}
+
+	flagMemberOrganisation string
 )
 
 func init() {
-	CmdRunner.Use(cmdMembers)
+	CmdRunner.Use(cmdTeams)
 }
 
-func listMembers(client *github.Client, cmd *Command, args *Args) {
+func listTeams(client *github.Client, cmd *Command, args *Args) {
 	utils.CheckClient(client)
 
 	org, err := GetOrg(args)
 	utils.Check(err)
 
-	opt := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 40},
+	opt := &github.ListOptions{
+		PerPage: 40,
 	}
 
-	var allUsers []github.User
+	var allTeams []github.Team
 	for {
-		users, resp, err := client.Organizations.ListMembers(org, opt)
+		teams, resp, err := client.Organizations.ListTeams(org, opt)
 
 		if err != nil {
 			ui.Errorln(err)
 			return
 		}
-		allUsers = append(allUsers, users...)
+		allTeams = append(allTeams, teams...)
 		if resp.NextPage == 0 {
 			break
 		}
-		opt.ListOptions.Page = resp.NextPage
+		opt.Page = resp.NextPage
 		HttpCleanup(resp)
 	}
 
 	var doc bytes.Buffer
 	enc := json.NewEncoder(&doc)
-	err = enc.Encode(allUsers)
+	err = enc.Encode(allTeams)
 
 	utils.Check(err)
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,7 @@ package version
 
 import "fmt"
 
-var Version = "0.0.1"
+var Version = "0.0.2"
 
 func FullVersion() string {
 	return fmt.Sprintf("ghcli %s", Version)


### PR DESCRIPTION
Also, change the command line format.

members and teams now expect the next parameter to be the organisation
name, rather than passing it as a flag.
